### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 >
 > Please report any issues you encounter to help improve the project.
 
+<a href="https://glama.ai/mcp/servers/@coderjun/shaka-packager-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@coderjun/shaka-packager-mcp-server/badge" alt="Shaka Packager Server MCP server" />
+</a>
+
 An MCP (Model Context Protocol) server that integrates [Shaka Packager](https://shaka-project.github.io/shaka-packager/) with Claude AI applications for video transcoding, packaging, and analysis.
 
 This server works with the [Filesystem MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) to enable Claude Desktop to access and process video files on your computer, turning Claude into a powerful assistant for media processing tasks.


### PR DESCRIPTION
This PR adds a badge for the [Shaka Packager MCP Server](https://glama.ai/mcp/servers/@coderjun/shaka-packager-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@coderjun/shaka-packager-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@coderjun/shaka-packager-mcp-server/badge" alt="Shaka Packager Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.